### PR TITLE
reverted order of sections, minor typos

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,11 +6,11 @@
   * [Creating a Data Store](creating-a-data-store.md)
   * [Publishing a Layer](publishing-a-layer.md)
 * [Rendering Data in OpenLayers](rendering-data-in-openlayers.md)
-  * [Enabling CORS in GeoServer](enabling-cors-in-geoserver.md)
   * [Adding a Base Map](rendering-data-in-openlayers/adding-a-base-map.md)
-  * [Making It Interactive](rendering-data-in-openlayers/making-it-interactive.md)
-  * [Styling Features](rendering-data-in-openlayers/styling-features.md)
+  * [Enabling CORS in GeoServer](enabling-cors-in-geoserver.md)
   * [Fetching Parks Data](rendering-data-in-openlayers/fetching-parks-data.md)
+  * [Styling Features](rendering-data-in-openlayers/styling-features.md)
+  * [Making It Interactive](rendering-data-in-openlayers/making-it-interactive.md)
 * [Extending Your Application](extending-your-application.md)
 
 

--- a/enabling-cors-in-geoserver.md
+++ b/enabling-cors-in-geoserver.md
@@ -1,10 +1,10 @@
 # Enabling CORS in GeoServer
 
-CORS stands for **Cross-Origin Resource Sharing**, and it refers to the ability of a JavaScript resource from one origin to access resrouces from another origin.
+CORS stands for **Cross-Origin Resource Sharing**, and it refers to the ability of a JavaScript resource from one origin to access resources from another origin.
 
 For example, a script hosted at `mydomain.com` may not access resources at `yourdomain.com` unless the latter domain allows it to do so. This is a security precaution, to prevent malicious scripts from accessing resources they shouldn't have access to. Most servers disable CORS to some degree \(or entirely\). Resource sharing can be enabled at-large \(for requests from any origin\) or on a case-by-case basis \(only for some origins\).
 
-We encourage you to [read more about CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), as it is an essntial topic for anybody doing front-end development.
+We encourage you to [read more about CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), as it is an essential topic for anybody doing front-end development.
 
 If you were to try to access data from GeoServer \(hosted at `localhost:8080`\) via your OpenLayers/JavaScript app \(hosted at `localhost:3000`\) you would likely see an error in  your browser console referring to the `Access-Control-Allow-Origin` HTTP header \(i.e. GeoServer\). This header is set by the server that is restricting cross-origin access. To enable CORS, we need to update GeoServer's configuration.
 


### PR DESCRIPTION
Hey Chris, for some reason the chapters in the "Rendering Data in OpenLayers" section were out of order in the summary file.  It made it very confusing; I was being asked to interact with the parks layer when I hadn't actually added them yet.  (We put the CORS chapter second, hope that is ok). Also some minor typos in the CORS chapter.